### PR TITLE
Add callable resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+### Added
+
+* Callable resolves to create callables from various representations
+
+### Removed
+
+* `Middlewares\Utils\CallableHandler::resolve`
+
 ## 0.8.0 - 2016-12-22
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
         "friendsofphp/php-cs-fixer": "^2.0",
         "squizlabs/php_codesniffer": "^2.7",
         "slim/slim": "^3.5",
-        "guzzlehttp/psr7": "^1.3"
+        "guzzlehttp/psr7": "^1.3",
+        "container-interop/container-interop": "^1.1"
+    },
+    "suggest": {
+        "container-interop/container-interop": "Can be used to automatically resolve callables"
     },
     "autoload": {
         "psr-4": {

--- a/src/CallableHandler.php
+++ b/src/CallableHandler.php
@@ -2,84 +2,14 @@
 
 namespace Middlewares\Utils;
 
+use Middlewares\Utils\CallableResolver\ReflectionResolver;
 use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
-use ReflectionMethod;
-use ReflectionClass;
 
 /**
  * Simple class to execute callables and returns responses.
  */
 abstract class CallableHandler
 {
-    /**
-     * Resolves the callable.
-     *
-     * @param mixed $callable
-     * @param array $args
-     *
-     * @throws RuntimeException If it's not callable
-     *
-     * @return callable
-     */
-    public static function resolve($callable, array $args = [])
-    {
-        if (is_string($callable)) {
-            $class = self::resolveClass($callable);
-
-            if (is_array($class)) {
-                list($class, $method) = $class;
-
-                $refMethod = new ReflectionMethod($class, $method);
-
-                if (!$refMethod->isStatic()) {
-                    $refClass = new ReflectionClass($class);
-
-                    if ($refClass->hasMethod('__construct')) {
-                        $instance = $refClass->newInstanceArgs($args);
-                    } else {
-                        $instance = $refClass->newInstance();
-                    }
-
-                    $callable = [$instance, $method];
-                }
-            }
-        }
-
-        if (is_callable($callable)) {
-            return $callable;
-        }
-
-        throw new RuntimeException('Invalid callable provided');
-    }
-
-    /**
-     * Resolves a callable class.
-     *
-     * @param string $class
-     *
-     * @return array|false
-     */
-    private static function resolveClass($class)
-    {
-        //ClassName::method
-        if (strpos($class, '::') !== false) {
-            list($class, $method) = explode('::', $class, 2);
-
-            if (!class_exists($class)) {
-                throw new RuntimeException("The class {$class} does not exists");
-            }
-
-            return [$class, $method];
-        }
-
-        if (class_exists($class)) {
-            return [$class, '__invoke'];
-        }
-
-        return false;
-    }
-
     /**
      * Execute the callable.
      *

--- a/src/CallableResolver/CallableResolverInterface.php
+++ b/src/CallableResolver/CallableResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Middlewares\Utils\CallableResolver;
+
+use RuntimeException;
+
+/**
+ * Simple interface to resolve callableish values.
+ */
+interface CallableResolverInterface
+{
+    /**
+     * Resolves a callable.
+     *
+     * @param mixed $callable
+     * @param array $args
+     *
+     * @throws RuntimeException If it's not callable
+     *
+     * @return callable
+     */
+    public function resolve($callable, array $args = []);
+}

--- a/src/CallableResolver/ContainerResolver.php
+++ b/src/CallableResolver/ContainerResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Middlewares\Utils\CallableResolver;
+
+use Closure;
+use Interop\Container\ContainerInterface;
+use RuntimeException;
+
+/**
+ * Resolve a callable using a container.
+ */
+final class ContainerResolver extends Resolver
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function resolve($callable, array $args = [])
+    {
+        if (is_string($callable)) {
+            $callable = $this->resolveString($callable);
+        }
+
+        if (is_string($callable)) {
+            $callable = $this->container->get($callable);
+        } elseif (is_array($callable) && is_string($callable[0])) {
+            $callable[0] = $this->container->get($callable[0]);
+        }
+
+        if (is_callable($callable)) {
+            return $callable;
+        }
+
+        throw new RuntimeException('Invalid callable provided');
+    }
+}

--- a/src/CallableResolver/ReflectionResolver.php
+++ b/src/CallableResolver/ReflectionResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Middlewares\Utils\CallableResolver;
+
+use Closure;
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+
+/**
+ * Resolve a callable using reflection.
+ */
+final class ReflectionResolver extends Resolver
+{
+    public function resolve($callable, array $args = [])
+    {
+        if (is_string($callable)) {
+            $callable = $this->resolveString($callable);
+        }
+
+        if (is_string($callable)) {
+            if (!function_exists($callable)) {
+                $callable = $this->createClass($callable, $args);
+            }
+        } elseif (is_array($callable) && is_string($callable[0])) {
+            list($class, $method) = $callable;
+
+            $refMethod = new ReflectionMethod($class, $method);
+
+            if (!$refMethod->isStatic()) {
+                $class = $this->createClass($class, $args);
+
+                $callable = [$class, $method];
+            }
+        }
+
+        if (is_callable($callable)) {
+            return $callable;
+        }
+
+        throw new RuntimeException('Invalid callable provided');
+    }
+
+    /**
+     * Create a new class.
+     *
+     * @param string $class
+     * @param array  $args
+     *
+     * @return object
+     */
+    private function createClass($class, $args = [])
+    {
+        if (!class_exists($class)) {
+            throw new RuntimeException("The class {$class} does not exists");
+        }
+
+        $refClass = new ReflectionClass($class);
+
+        if ($refClass->hasMethod('__construct')) {
+            $instance = $refClass->newInstanceArgs($args);
+        } else {
+            $instance = $refClass->newInstance();
+        }
+
+        return $instance;
+    }
+}

--- a/src/CallableResolver/Resolver.php
+++ b/src/CallableResolver/Resolver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Middlewares\Utils\CallableResolver;
+
+/**
+ * Common logic for callable resolvers.
+ */
+abstract class Resolver implements CallableResolverInterface
+{
+    /**
+     * Resolves a callable from a string.
+     *
+     * @param string $callable
+     *
+     * @return array|string
+     */
+    protected function resolveString($callable)
+    {
+        //ClassName/Service::method
+        if (strpos($callable, '::') !== false) {
+            list($id, $method) = explode('::', $callable, 2);
+
+            return [$id, $method];
+        }
+
+        return $callable;
+    }
+}

--- a/tests/CallableHandlerTest.php
+++ b/tests/CallableHandlerTest.php
@@ -6,27 +6,6 @@ use Middlewares\Utils\CallableHandler;
 
 class CallableHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testResolve()
-    {
-        $function = function () {
-        };
-        $callable = CallableHandler::resolve($function);
-
-        $this->assertSame($function, $callable);
-
-        $function = 'sprintf';
-        $callable = CallableHandler::resolve($function);
-
-        $this->assertSame($function, $callable);
-
-        $function = __METHOD__;
-        $callable = CallableHandler::resolve($function);
-
-        $this->assertTrue(is_array($callable));
-        $this->assertInstanceOf(__CLASS__, $callable[0]);
-        $this->assertEquals('testResolve', $callable[1]);
-    }
-
     public function testExecute()
     {
         $response = CallableHandler::execute('sprintf', ['Hello %s', 'World']);

--- a/tests/CallableResolver/ContainerResolverTest.php
+++ b/tests/CallableResolver/ContainerResolverTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Middlewares\Tests\CallableResolver;
+
+use Interop\Container\ContainerInterface;
+use Middlewares\Utils\CallableResolver\CallableResolverInterface;
+use Middlewares\Utils\CallableResolver\ContainerResolver;
+use Prophecy\Prophecy\ObjectProphecy;
+
+final class ContainerResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCallableResolver()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $this->assertInstanceOf(CallableResolverInterface::class, $resolver);
+    }
+
+    public function testResolveClass()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get(ControllerStub::class)->willReturn(new ControllerStub());
+
+        $callable = $resolver->resolve(ControllerStub::class);
+
+        $this->assertInstanceOf(ControllerStub::class, $callable);
+    }
+
+    public function testResolveClassCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get(ControllerStub::class)->willReturn(new ControllerStub());
+
+        $callable = $resolver->resolve(ControllerStub::class.'::action');
+
+        $this->assertInstanceOf(ControllerStub::class, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveClassArrayCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get(ControllerStub::class)->willReturn(new ControllerStub());
+
+        $callable = $resolver->resolve([ControllerStub::class, 'action']);
+
+        $this->assertInstanceOf(ControllerStub::class, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveServiceCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get('controller')->willReturn(new ControllerStub());
+
+        $callable = $resolver->resolve('controller::action');
+
+        $this->assertInstanceOf(ControllerStub::class, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveServiceArrayCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get('controller')->willReturn(new ControllerStub());
+
+        $callable = $resolver->resolve(['controller', 'action']);
+
+        $this->assertInstanceOf(ControllerStub::class, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveObjectCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get(ControllerStub::class)->shouldNotBeCalled();
+
+        $callable = $resolver->resolve($controllerStub = new ControllerStub());
+
+        $this->assertSame($controllerStub, $callable);
+    }
+
+    public function testResolveObjectArrayCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get(ControllerStub::class)->shouldNotBeCalled();
+
+        $callable = $resolver->resolve([$controllerStub = new ControllerStub(), 'action']);
+
+        $this->assertSame($controllerStub, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveServiceClosureCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $closure = function () {
+        };
+
+        $container->get('controller')->willReturn($closure);
+
+        $callable = $resolver->resolve('controller');
+
+        $this->assertSame($closure, $callable);
+    }
+
+    public function testResolveServiceFunctionCallable()
+    {
+        /** @var ContainerInterface|ObjectProphecy $container */
+        $container = $this->prophesize(ContainerInterface::class);
+        $resolver = new ContainerResolver($container->reveal());
+
+        $container->get('controller')->willReturn('is_string');
+
+        $callable = $resolver->resolve('controller');
+
+        $this->assertEquals('is_string', $callable);
+    }
+}

--- a/tests/CallableResolver/ControllerStub.php
+++ b/tests/CallableResolver/ControllerStub.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Middlewares\Tests\CallableResolver;
+
+final class ControllerStub
+{
+    public function action()
+    {
+    }
+
+    public function __invoke()
+    {
+    }
+}

--- a/tests/CallableResolver/ReflectionResolverTest.php
+++ b/tests/CallableResolver/ReflectionResolverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Middlewares\Tests\CallableResolver;
+
+use Middlewares\Utils\CallableResolver\CallableResolverInterface;
+use Middlewares\Utils\CallableResolver\ReflectionResolver;
+
+final class ReflectionResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCallableResolver()
+    {
+        $resolver = new ReflectionResolver();
+
+        $this->assertInstanceOf(CallableResolverInterface::class, $resolver);
+    }
+
+    public function testResolveClass()
+    {
+        $resolver = new ReflectionResolver();
+
+        $callable = $resolver->resolve(ControllerStub::class);
+
+        $this->assertInstanceOf(ControllerStub::class, $callable);
+    }
+
+    public function testResolveClassCallable()
+    {
+        $resolver = new ReflectionResolver();
+
+        $callable = $resolver->resolve(ControllerStub::class.'::action');
+
+        $this->assertInstanceOf(ControllerStub::class, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveClassArrayCallable()
+    {
+        $resolver = new ReflectionResolver();
+
+        $callable = $resolver->resolve([ControllerStub::class, 'action']);
+
+        $this->assertInstanceOf(ControllerStub::class, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+
+    public function testResolveObjectCallable()
+    {
+        $resolver = new ReflectionResolver();
+
+        $callable = $resolver->resolve($controllerStub = new ControllerStub());
+
+        $this->assertSame($controllerStub, $callable);
+    }
+
+    public function testResolveObjectArrayCallable()
+    {
+        $resolver = new ReflectionResolver();
+
+        $callable = $resolver->resolve([$controllerStub = new ControllerStub(), 'action']);
+
+        $this->assertSame($controllerStub, $callable[0]);
+        $this->assertEquals('action', $callable[1]);
+    }
+}


### PR DESCRIPTION
After thinking about #2 I came up with a bit more complex solution. This solution completely delegates the resolution to one or other resolver, allowing to support resolver specific features (like service id based resolution with a container).
