### PR TITLE
Add "conflict" option with old http-interop/http-middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "guzzlehttp/psr7": "^1.3",
         "psr/container": "^1.0"
     },
+    "conflict": {
+        "http-interop/http-middleware": "*"
+    },
     "suggest": {
         "psr/container": "Can be used to automatically resolve callables"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/container": "^1.0"
     },
     "conflict": {
-        "http-interop/http-middleware": "*"
+        "http-interop/http-middleware": "<0.5"
     },
     "suggest": {
         "psr/container": "Can be used to automatically resolve callables"


### PR DESCRIPTION
This PR fixes #5 by stating that middleware/utils 0.13+ should not be used if "http-interop/http-middleware" is used.
This will force a fallback to older versions of middleware/utils.