### PR TITLE
Exchange abandoned http-interop/http-factory with psr/http-factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.0] - 2018-08-01
+
+### Changed
+
+- Exchanged abandoned `http-interop/http-factory` with `psr/http-factory`
+
 ## [1.2.0] - 2018-07-17
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "require": {
         "php": "^7.0",
         "psr/http-message": "^1.0",
-        "http-interop/http-factory": "^0.4",
         "psr/http-server-middleware": "^1.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,10 +3,10 @@ declare(strict_types = 1);
 
 namespace Middlewares\Utils;
 
-use Interop\Http\Factory\ResponseFactoryInterface;
-use Interop\Http\Factory\ServerRequestFactoryInterface;
-use Interop\Http\Factory\StreamFactoryInterface;
-use Interop\Http\Factory\UriFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;

--- a/src/Factory/ResponseFactory.php
+++ b/src/Factory/ResponseFactory.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Middlewares\Utils\Factory;
 
-use Interop\Http\Factory\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Middlewares\Utils\Factory;
 
-use Interop\Http\Factory\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Middlewares\Utils\Factory;
 
-use Interop\Http\Factory\StreamFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 

--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Middlewares\Utils\Factory;
 
-use Interop\Http\Factory\UriFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 use RuntimeException;
 


### PR DESCRIPTION
This pull request will exchange the abandoned dependency `http-interop/http-factory` with the recommended `psr/http-factory`.