### PR TITLE
added slim/psr7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ composer require middlewares/utils
 
 ## Factory
 
-Used to create psr-7 instances of `ServerRequestInterface`, `ResponseInterface`, `StreamInterface` and `UriInterface`. Detects automatically [Diactoros](https://github.com/zendframework/zend-diactoros), [Guzzle](https://github.com/guzzle/psr7), [Slim](https://github.com/slimphp/Slim) and [Nyholm/psr7](https://github.com/Nyholm/psr7) but you can register a different factory using the [psr/http-factory](https://github.com/php-fig/http-factory) interface.
+Used to create psr-7 instances of `ServerRequestInterface`, `ResponseInterface`, `StreamInterface` and `UriInterface`. Detects automatically [Diactoros](https://github.com/zendframework/zend-diactoros), [Guzzle](https://github.com/guzzle/psr7), [Slim](https://github.com/slimphp/Slim), [Slim/psr7](https://github.com/slimphp/Slim-Psr7) and [Nyholm/psr7](https://github.com/Nyholm/psr7) but you can register a different factory using the [psr/http-factory](https://github.com/php-fig/http-factory) interface.
 
 ```php
 use Middlewares\Utils\Factory;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "friendsofphp/php-cs-fixer": "^2.0",
         "squizlabs/php_codesniffer": "^3.0",
         "slim/http": "^0.3",
-        "guzzlehttp/psr7": "^1.3"
+        "guzzlehttp/psr7": "^1.3",
+        "slim/psr7": "^0.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ namespace Middlewares\Utils;
 use Middlewares\Utils\Factory\DiactorosFactory;
 use Middlewares\Utils\Factory\GuzzleFactory;
 use Middlewares\Utils\Factory\SlimFactory;
+use Middlewares\Utils\Factory\SlimPsr7Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -25,6 +26,7 @@ abstract class Factory
         DiactorosFactory::class,
         GuzzleFactory::class,
         SlimFactory::class,
+        SlimPsr7Factory::class,
         'Nyholm\Psr7\Factory\Psr17Factory',
     ];
 

--- a/src/Factory/SlimPsr7Factory.php
+++ b/src/Factory/SlimPsr7Factory.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types = 1);
+
+namespace Middlewares\Utils\Factory;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Factory\UriFactory;
+
+/**
+ * Simple class to create response instances of PSR-7 classes.
+ */
+class SlimPsr7Factory implements
+    ResponseFactoryInterface,
+    ServerRequestFactoryInterface,
+    StreamFactoryInterface,
+    UriFactoryInterface
+{
+    private static $factories = [];
+
+    /**
+     * Check whether Slim 4 PSR-7 is available
+     */
+    public static function isInstalled(): bool
+    {
+        return class_exists('Slim\\Psr7\\Factory\\ResponseFactory')
+            && class_exists('Slim\\Psr7\\Factory\\ServerRequestFactory')
+            && class_exists('Slim\\Psr7\\Factory\\StreamFactory')
+            && class_exists('Slim\\Psr7\\Factory\\UriFactory');
+    }
+
+    /**
+     * @see ResponseFactoryInterface
+     */
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        return (self::$factories['response'] = self::$factories['response'] ?? new ResponseFactory())
+            ->createResponse($code, $reasonPhrase);
+    }
+
+    /**
+     * @see ServerRequestFactoryInterface
+     * @param mixed $uri
+     */
+    public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface
+    {
+        return (self::$factories['request'] = self::$factories['request'] ?? new ServerRequestFactory())
+            ->createServerRequest($method, $uri, $serverParams);
+    }
+
+    /**
+     * @see StreamFactoryInterface
+     */
+    public function createStream(string $content = ''): StreamInterface
+    {
+        $stream = $this->createStreamFromFile('php://temp', 'r+');
+        $stream->write($content);
+
+        return $stream;
+    }
+
+    /**
+     * @see StreamFactoryInterface
+     */
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        return $this->createStreamFromResource(fopen($filename, $mode));
+    }
+
+    /**
+     * @see StreamFactoryInterface
+     * @param mixed $resource
+     */
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        return (self::$factories['stream'] = self::$factories['stream'] ?? new StreamFactory())
+            ->createStreamFromResource($resource);
+    }
+
+    /**
+     * @see UriFactoryInterface
+     */
+    public function createUri(string $uri = ''): UriInterface
+    {
+        return (self::$factories['uri'] = self::$factories['uri'] ?? new UriFactory())
+            ->createUri($uri);
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -7,6 +7,7 @@ use Middlewares\Utils\Factory;
 use Middlewares\Utils\Factory\DiactorosFactory;
 use Middlewares\Utils\Factory\GuzzleFactory;
 use Middlewares\Utils\Factory\SlimFactory;
+use Middlewares\Utils\Factory\SlimPsr7Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -136,6 +137,17 @@ class FactoryTest extends TestCase
                 SlimFactory::class,
                 SlimFactory::class,
                 SlimFactory::class,
+            ],
+            [
+                [
+                    SlimPsr7Factory::class,
+                    GuzzleFactory::class,
+                    DiactorosFactory::class,
+                ],
+                SlimPsr7Factory::class,
+                SlimPsr7Factory::class,
+                SlimPsr7Factory::class,
+                SlimPsr7Factory::class,
             ],
             [
                 [


### PR DESCRIPTION
Slim 4 now [no longer has it's PSR-7 implementation bundled](http://www.slimframework.com/docs/v4/start/installation.html#step-3-install-a-psr-7-implementation-and-serverrequest-creator). 
It's now at https://github.com/slimphp/Slim-Psr7.

But `slim/psr7 0.6 requires php ^7.1` though, which causes PHP 7.0 tests failed.