### PR TITLE
[#20] zend-diactoros is deprecated by laminas/laminas-diactoros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.1",
-        "zendframework/zend-diactoros": "^2.0.1",
+        "laminas/laminas-diactoros": "^2.2",
         "friendsofphp/php-cs-fixer": "^2.0",
         "oscarotero/php-cs-fixer-config": "^1.0",
         "squizlabs/php_codesniffer": "^3.0",

--- a/src/FactoryDiscovery.php
+++ b/src/FactoryDiscovery.php
@@ -17,12 +17,12 @@ use RuntimeException;
 class FactoryDiscovery implements FactoryInterface
 {
     const DIACTOROS = [
-        'request' => 'Zend\Diactoros\RequestFactory',
-        'response' => 'Zend\Diactoros\ResponseFactory',
-        'serverRequest' => 'Zend\Diactoros\ServerRequestFactory',
-        'stream' => 'Zend\Diactoros\StreamFactory',
-        'uploadedFile' => 'Zend\Diactoros\UploadedFileFactory',
-        'uri' => 'Zend\Diactoros\UriFactory',
+        'request' => 'Laminas\Diactoros\RequestFactory',
+        'response' => 'Laminas\Diactoros\ResponseFactory',
+        'serverRequest' => 'Laminas\Diactoros\ServerRequestFactory',
+        'stream' => 'Laminas\Diactoros\StreamFactory',
+        'uploadedFile' => 'Laminas\Diactoros\UploadedFileFactory',
+        'uri' => 'Laminas\Diactoros\UriFactory',
     ];
     const GUZZLE = 'GuzzleHttp\Psr7\HttpFactory';
     const SLIM = [

--- a/tests/Factory/FactoryDiactorosTest.php
+++ b/tests/Factory/FactoryDiactorosTest.php
@@ -11,12 +11,12 @@ use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
-use Zend\Diactoros\RequestFactory;
-use Zend\Diactoros\ResponseFactory;
-use Zend\Diactoros\ServerRequestFactory;
-use Zend\Diactoros\StreamFactory;
-use Zend\Diactoros\UploadedFileFactory;
-use Zend\Diactoros\UriFactory;
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\UploadedFileFactory;
+use Laminas\Diactoros\UriFactory;
 
 class FactoryDiactorosTest extends TestCase
 {


### PR DESCRIPTION
- Updated the composer require-dev section to laminas
- Updated the Tests to the Laminas namespace
- Updated the Factory Discovery to the Laminas namespace